### PR TITLE
Added ability to keep track of rooms

### DIFF
--- a/GameMultiplayer.py
+++ b/GameMultiplayer.py
@@ -28,9 +28,10 @@ class GameMultiplayer:
             elif mp_game_mode == '1':
                 roomID = input("Pick a room ID for everyone to join!:")
             roomIDStripped = "".join(roomID.split())
-            self.mp_game_mode = mp_game_mode
+
+            self.isHost = True if mp_game_mode == '1' else False
             self.roomID = roomIDStripped
-            print("Multiplayer game mode:", mp_game_mode, "roomID", roomIDStripped)
+            print("Multiplayer game mode(isHost):", self.isHost, "roomID", roomIDStripped)
 
         # pygame initialization
         pygame.init()
@@ -43,7 +44,7 @@ class GameMultiplayer:
         #Server setup
         self.server = Server.Server()
         self.server.fetchEnemies()  # Make socket call to fetch and set enemy types
-        self.server.connect(self.roomID, self.mp_game_mode) #connect to room
+        self.server.connect(self.roomID, self.isHost) #connect to room
 
         self.clock = pygame.time.Clock()
         self.clouds = []

--- a/Server.py
+++ b/Server.py
@@ -69,12 +69,9 @@ class Server:
 
             self.opponent_rangers = opponent_rangers
 
-    def connect(self, roomID, mp_game_mode):
-        if mp_game_mode != '0' and mp_game_mode != '1':
-            raise Exception("Multiplayer game mode must be either 0 (join existing room) or 1 (create new room)")
-
-        eventName = "joinExistingRoom" if mp_game_mode == '0' else "joinNewRoom"
-        self.isHost = False if mp_game_mode == '0' else True
+    def connect(self, roomID, isHost):
+        eventName = "joinNewRoom" if isHost else "joinExistingRoom"
+        self.isHost = isHost
         self.roomID = roomID
         self.socket.emit(eventName, {
             'roomID': roomID


### PR DESCRIPTION
After this commit, the server has the capability to keep track of multiple rooms (2+) with each having multiple rangers (2+).
In addition, the python client now knows about who the other rangers are in the room. When the a user disconnects from the server/room, it will remove them from the dictionary keeping track of that information.

Python client also sends coordinates of it's current ranger to the server. Not yet done implementing.